### PR TITLE
Refactor image to support multiple tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,17 +6,17 @@ in conjunction with docker-compose.
 
 Example running w/ PlayFramework:
 
-    docker run -v /local/code:/root/app -p 9000:9000 pitchplay/scala-dev run
+    docker run -v /local/code:/usr/src/app -p 9000:9000 pitchplay/scala-dev:jdk8-web run
 
-Features
---------
 
-| Feature      | Description                                        |
-| ------------ | -------------------------------------------------- |
-| Base Image   | Uses the base JDK-8 image from the Docker library  |
-| SBT          | Provided by the fantastic [sbt-extras] wrapper     |
-| Scala        | Pre-seeded with Scala 2.11.6                       |
-| Node         | Support for many PlayFramework sbt-web plugins     |
+Supported Tags
+--------------
+
+ Tag          | Description
+ ------------ | ---------------------------------------------------------------------- 
+ jdk8         | Uses the base JDK-8 image from the Docker library, in conjunction with the fantastic [sbt-extras] wrapper
+ jdk8-web     | Support for many PlayFramework sbt-web plugins (via node)
+ jdk8-onbuild | Automatically copies working code into image on creation, for use in CI/CD builds
 
 
 [sbt-extras]: https://github.com/paulp/sbt-extras

--- a/jdk8/Dockerfile
+++ b/jdk8/Dockerfile
@@ -1,0 +1,12 @@
+FROM java:8-jdk
+MAINTAINER Evan Lowry <evan@pitchplay.io>
+
+WORKDIR /usr/bin
+
+# Install SBT
+RUN wget https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt \
+    && chmod +x sbt
+RUN ./sbt -sbt-create -211
+
+ENTRYPOINT ["/usr/bin/sbt"]
+CMD ["-h"]

--- a/jdk8/onbuild/Dockerfile
+++ b/jdk8/onbuild/Dockerfile
@@ -1,0 +1,8 @@
+# onbuild
+FROM pitchplay/scala-dev:jdk8
+MAINTAINER Evan Lowry <evan@pitchplay.io>
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
+
+ONBUILD COPY . /usr/src/app

--- a/jdk8/web/Dockerfile
+++ b/jdk8/web/Dockerfile
@@ -1,13 +1,6 @@
-# Image: pitchplay/scala-dev
-FROM java:8-jdk
+# web
+FROM pitchplay/scala-dev:jdk8
 MAINTAINER Evan Lowry <evan@pitchplay.io>
-
-WORKDIR /root
-
-# Install SBT
-RUN wget https://raw.githubusercontent.com/paulp/sbt-extras/master/sbt \
-    && chmod +x sbt
-RUN ./sbt -sbt-create -211
 
 # Install Node
 ENV NODE_VERSION 0.12.5
@@ -19,8 +12,8 @@ RUN curl -SLO "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-
     && npm cache clear
 
 # Setup code location
-RUN mkdir -p /root/app
-WORKDIR /root/app
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app
 
-ENTRYPOINT ["/root/sbt"]
+ENTRYPOINT ["/usr/bin/sbt"]
 CMD ["-h"]


### PR DESCRIPTION
Similar to how docker library handles multiple python/java/etc
versions in one repository, this refactor is to break the commonalities
out and start building versioned tags with the autobuild system instead
of just relying on latest.

Also adds support for having different types of images (such as onbuild),
which comes in handy when dealing w/ CI systems.
